### PR TITLE
(fix) User is navigated to login when the access key expired

### DIFF
--- a/src/components/FetchData.tsx
+++ b/src/components/FetchData.tsx
@@ -18,7 +18,13 @@ export function fetchData (url: any, method: any, data = '', header: any) {
     method,
     headers: header,
     body: data
-  }).then((response) => response.json())
+  }).then((response) => {
+    if (response.status === 403) {
+      logout_and_navigate_to_login()
+      return null
+    } 
+    return response.json()
+  })
 }
 
 export function fetchRawData (url: any, method: any, data = '', header: any) {
@@ -26,5 +32,23 @@ export function fetchRawData (url: any, method: any, data = '', header: any) {
     method,
     headers: header,
     body: data
-  }).then((response) => response)
+  }).then((response) => {
+    if (response.status === 403) {
+      logout_and_navigate_to_login()
+      return null
+    } 
+    return response
+  })
+}
+
+function logout_and_navigate_to_login () {
+  localStorage.clear()
+  
+  // Normally setting window.location.href in a SPA is not a good practice.
+  // However, since we use this function only when a user token cannot be
+  // authenticated (e.i. fetch function returns a 403 status code) 
+  // (either because it has expired or corrupted) to navigate the user to 
+  // the login page, it seems acceptable to set window.location.href for this 
+  // scenario
+  window.location.href = '/login'
 }


### PR DESCRIPTION
 User is navigated to login when the access key expired

Log in (front end)
Open browser developer tools
Locate application --> localstorage --> localhost:3000 --> Token
Make some changes to token (change a character for example) (do not delete it completely)
Try any action that requires data fetch from the backend (e.g. click any menu item on sidebar)